### PR TITLE
Multiple tweaks and real-time adjustments during first drive practice…

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -19,8 +19,6 @@ import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.util.Color;
 
-
-/** Add your docs here. */
 public class Constants {
 
     public static final class Controllers {
@@ -33,12 +31,12 @@ public class Constants {
         /**
          * The CAN ID of the extension motor.
          */
-        public static final int kExtensionMotorId = 21; // TODO: Fix
+        public static final int kExtensionMotorId = 21;
 
         /*
          * The CAN ID of the elevation motor.
          */
-        public static final int kTiltMotorId = 20; // TODO: Fix
+        public static final int kTiltMotorId = 20;
 
         /*
          * The gear ratio for the arm that converts motor rotations into inches
@@ -59,7 +57,7 @@ public class Constants {
          /*
          * The maximum distance (in inches) that the arm can retract.
          */
-        public static final double kExtendReverseLimit = 0.0; 
+        public static final double kExtendReverseLimit = 0.25; // HACK: to prevent the lead screw from ramming in
 
          /*
          * The maximum distance (in inches) that the arm can elevate.
@@ -73,7 +71,6 @@ public class Constants {
 
         public static final double kMinSafeTilt = 2.6;
 
-        
         /*
          * Tilt PID Controller
          */
@@ -99,7 +96,6 @@ public class Constants {
          * Extension Max Speed
          */
         public static final double kExtensionMaxOutput = 1;
-
 
         /*
          * High Cone Tilt Height
@@ -130,8 +126,6 @@ public class Constants {
          * Low Cone Extension
          */
         public static final double kLowConeExtend = 1;
-
-        
 
         /*
          * High Cube Tilt Height

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -46,7 +46,6 @@ public class Robot extends TimedRobot {
   public void autonomousInit() {
     DataLog.mode(RobotMode.AUTO);
     m_autonomousCommand = m_robotContainer.getAutonomousCommand();
-
     if (m_autonomousCommand != null) {
       m_autonomousCommand.schedule();
     }
@@ -84,8 +83,8 @@ public class Robot extends TimedRobot {
   @Override
   public void testExit() {}
 
-   /** This function provides static access to create a custom periodic function in the current robot instance. */
-   public static void addCustomPeriodic(Runnable callback, double periodSeconds) {
+  /** This function provides static access to create a custom periodic function in the current robot instance. */
+  public static void addCustomPeriodic(Runnable callback, double periodSeconds) {
     m_robotInstance.addPeriodic(callback, periodSeconds, 0.333);
   }
   

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -11,8 +11,8 @@ import com.pathplanner.lib.PathPlannerTrajectory;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+
 import frc.robot.commands.arm.ArmExtendOverride;
 import frc.robot.commands.arm.ArmTiltOverride;
 import frc.robot.commands.arm.ExtendArm;
@@ -20,15 +20,17 @@ import frc.robot.commands.arm.TiltArm;
 import frc.robot.commands.arm.MoveTo.MoveToHigh;
 import frc.robot.commands.arm.MoveTo.MoveToLow;
 import frc.robot.commands.arm.MoveTo.MoveToMedium;
+import frc.robot.commands.arm.MoveTo.MoveToPickup;
+import frc.robot.commands.arm.Score.ScoreHigh;
 import frc.robot.commands.arm.Score.ScoreMedium;
+import frc.robot.commands.auto.FollowTrajectory;
 import frc.robot.commands.drive.DriveRobotCentric;
 import frc.robot.commands.drive.DriveWithJoysticks;
 import frc.robot.commands.drive.ResetSwerve;
 import frc.robot.commands.drive.ZeroHeading;
-import frc.robot.commands.intake.RunRollersInward;
-import frc.robot.commands.intake.RunRollersOutward;
-import frc.robot.commands.suction.DisableSuction;
-import frc.robot.commands.suction.EnableSuction;
+//import frc.robot.commands.intake.RunRollersInward;
+//import frc.robot.commands.intake.RunRollersOutward;
+import frc.robot.commands.suction.ToggleSuction;
 import frc.robot.lib.Utils;
 import frc.robot.subsystems.Arm;
 import frc.robot.subsystems.Drive;
@@ -39,7 +41,7 @@ public class RobotContainer {
   private Drive m_drive = new Drive();
   private Suction m_suction = new Suction();
   private Arm m_arm = new Arm();
-  private Intake m_intake = new Intake();
+  private Intake m_intake = null; // HACK: disabling intake since not installed
 
   private final XboxController m_driverController = new XboxController(Constants.Controllers.kDriverControllerPort);
   private final XboxController m_manipulatorController = new XboxController(Constants.Controllers.kManipulatorControllerPort);
@@ -67,27 +69,24 @@ public class RobotContainer {
   private void setupTriggers() {
     
     //DRIVER
-    new Trigger(() -> Math.abs(m_driverController.getRightTriggerAxis()) > 0.1)
+    new Trigger(() -> Math.abs(m_driverController.getRightTriggerAxis()) > 0.9)
       .whileTrue(new DriveRobotCentric(m_drive));
 
     new Trigger(m_driverController::getBackButton)
       .onTrue(new ZeroHeading(m_drive));
 
     new Trigger(m_driverController::getStartButton)
-      .whileTrue(new ResetSwerve(m_drive));
+      .onTrue(new ResetSwerve(m_drive));
 
-    new Trigger(m_driverController::getAButton)
-      .whileTrue(new RunRollersInward(m_intake));
+    // new Trigger(m_driverController::getAButton)
+    //   .whileTrue(new RunRollersInward(m_intake));
 
-    new Trigger(m_driverController::getBButton)
-      .whileTrue(new RunRollersOutward(m_intake));
+    // new Trigger(m_driverController::getBButton)
+    //   .whileTrue(new RunRollersOutward(m_intake));
 
     //MANIPULATOR
     new Trigger(m_manipulatorController::getAButton)
-      .onTrue(new EnableSuction(m_suction));
-
-    new Trigger(m_manipulatorController::getBButton)
-      .onTrue(new DisableSuction(m_suction));
+      .onTrue(new ToggleSuction(m_suction));
 
     new Trigger(() -> Math.abs(m_manipulatorController.getLeftY()) > 0.1)
       .whileTrue(new ExtendArm(m_arm, m_manipulatorController::getLeftY));
@@ -104,25 +103,25 @@ public class RobotContainer {
     new Trigger(() -> m_manipulatorController.getPOV() == 0)
       .whileTrue(new MoveToHigh(m_arm, m_intake, 0.15));
 
+    new Trigger(() -> m_manipulatorController.getPOV() == 90)
+      .whileTrue(new MoveToMedium(m_arm, m_intake, 0.15));
+
     new Trigger(() -> m_manipulatorController.getPOV() == 180)
       .whileTrue(new MoveToLow(m_arm, m_intake, 0.15));
 
-    new Trigger(() -> m_manipulatorController.getPOV() == 90)
-      .whileTrue(new MoveToMedium(m_arm, m_intake, 0.15));
-
     new Trigger(() -> m_manipulatorController.getPOV() == 270)
-      .whileTrue(new MoveToMedium(m_arm, m_intake, 0.15));
+      .whileTrue(new MoveToPickup(m_arm, m_intake, 0.15));
 
-    new Trigger(() -> m_manipulatorController.getPOV() == 90)
+    new Trigger(() -> m_manipulatorController.getPOV() == 0)
       .and(m_manipulatorController::getYButton)
-      .whileTrue(new ScoreMedium(m_arm, m_intake, null, m_suction));
+      .whileTrue(new ScoreHigh(m_arm, m_intake, null, m_suction));
 
-    new Trigger(() -> m_manipulatorController.getPOV() == 270)
+    new Trigger(() -> m_manipulatorController.getPOV() == 90)
       .and(m_manipulatorController::getYButton)
       .whileTrue(new ScoreMedium(m_arm, m_intake, null, m_suction));
   }
 
   public Command getAutonomousCommand() {
-    return new RunCommand(() -> m_drive.drive(1.0, 0.0, 0.0), m_drive); // DriveWithJoysticks(m_drive, () -> 1.0, () -> 0.0, () -> 0.0); // FollowTrajectory(simplePath, true, m_drive);
+    return new FollowTrajectory(simplePath, true, m_drive);
   }
 }

--- a/src/main/java/frc/robot/commands/arm/ArmExtendOverride.java
+++ b/src/main/java/frc/robot/commands/arm/ArmExtendOverride.java
@@ -1,42 +1,39 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
+// Copyright (c) 2022 FRC Team 2881 - The Lady Cans
+//
+// Open Source Software; you can modify and/or share it under the terms of BSD
+// license file in the root directory of this project.
 
 package frc.robot.commands.arm;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+
 import frc.robot.subsystems.Arm;
 
 public class ArmExtendOverride extends CommandBase {
   private Arm m_arm;
-  /** Creates a new ArmTiltOverride. */
+
   public ArmExtendOverride(Arm arm) {
     m_arm = arm;
-    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(m_arm);
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {
     m_arm.enableExtendSoftLimits(false);
   }
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
     m_arm.runExtension(-0.10);
   }
 
-  // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
     m_arm.enableExtendSoftLimits(true);
     m_arm.resetExtensionEncoder();
-
     m_arm.runExtension(0.0);
   }
-
-  // Returns true when the command should end.
+  
   @Override
   public boolean isFinished() {
     return false;

--- a/src/main/java/frc/robot/commands/arm/ArmTiltOverride.java
+++ b/src/main/java/frc/robot/commands/arm/ArmTiltOverride.java
@@ -1,42 +1,39 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
+// Copyright (c) 2022 FRC Team 2881 - The Lady Cans
+//
+// Open Source Software; you can modify and/or share it under the terms of BSD
+// license file in the root directory of this project.
 
 package frc.robot.commands.arm;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+
 import frc.robot.subsystems.Arm;
 
 public class ArmTiltOverride extends CommandBase {
   private Arm m_arm;
-  /** Creates a new ArmTiltOverride. */
+
   public ArmTiltOverride(Arm arm) {
     m_arm = arm;
-    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(m_arm);
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {
     m_arm.enableTiltSoftLimits(false);
   }
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
     m_arm.runTilt(-0.15);
   }
 
-  // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
     m_arm.enableTiltSoftLimits(true);
     m_arm.resetTiltEncoder();
-
     m_arm.runTilt(0.0);
   }
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
     return false;

--- a/src/main/java/frc/robot/commands/arm/ExtendArm.java
+++ b/src/main/java/frc/robot/commands/arm/ExtendArm.java
@@ -8,28 +8,28 @@ package frc.robot.commands.arm;
 import java.util.function.DoubleSupplier;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+
 import frc.robot.subsystems.Arm;
 
-/** Extends the scoring arm. */
 public class ExtendArm extends CommandBase {
   private Arm m_arm;
   private DoubleSupplier m_speed;
 
   public ExtendArm(Arm arm, DoubleSupplier speed) {
     m_arm = arm;
+    addRequirements(m_arm);
+
     m_speed = speed;
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {}
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    boolean isSafe = true; //m_arm.isSafeToExtend();
-    if(isSafe == true){
-      m_arm.runExtension(m_speed.getAsDouble());
+    boolean isSafe = true; // TODO: m_arm.isSafeToExtend();
+    if (isSafe) {
+      m_arm.runExtension(-m_speed.getAsDouble());
     }
   }
 

--- a/src/main/java/frc/robot/commands/arm/ExtendArmToLength.java
+++ b/src/main/java/frc/robot/commands/arm/ExtendArmToLength.java
@@ -16,19 +16,18 @@ public class ExtendArmToLength extends CommandBase {
 
   public ExtendArmToLength(Arm arm, Double speed, Double position) {
     m_arm = arm;
-    m_position = position;
+    addRequirements(m_arm);
 
-    
+    m_speed = speed;
+    m_position = position;
   }
 
   @Override
   public void initialize() {
-    System.out.println("Extend Arm to Length");
-    boolean isSafe = true; //m_arm.isSafeToExtend();
-    if(isSafe == true){
+    boolean isSafe = true; // TODO: m_arm.isSafeToExtend();
+    if (isSafe) {
       m_arm.setDesiredExtensionPosition(m_position);
-    }
-    
+    } 
   }
 
   @Override
@@ -37,13 +36,8 @@ public class ExtendArmToLength extends CommandBase {
   @Override
   public void end(boolean interrupted) {}
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    if(Math.abs(m_arm.getExtensionEncoderPosition() - m_position) < 0.1) {
-      return true;
-    } else {
-      return false;
-    }
+    return Math.abs(m_arm.getExtensionEncoderPosition() - m_position) < 0.1;
   }
 }

--- a/src/main/java/frc/robot/commands/arm/MoveTo/MoveToHigh.java
+++ b/src/main/java/frc/robot/commands/arm/MoveTo/MoveToHigh.java
@@ -1,24 +1,22 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
+// Copyright (c) 2022 FRC Team 2881 - The Lady Cans
+//
+// Open Source Software; you can modify and/or share it under the terms of BSD
+// license file in the root directory of this project.
 
 package frc.robot.commands.arm.MoveTo;
 
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+
 import frc.robot.commands.arm.ExtendArmToLength;
 import frc.robot.commands.arm.TiltArmToHeight;
 import frc.robot.subsystems.Arm;
 import frc.robot.subsystems.Intake;
 
-// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
-// information, see:
-// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
 public class MoveToHigh extends SequentialCommandGroup {
-  /** Creates a new MoveToHigh. */
-  public MoveToHigh(Arm arm, Intake intake, Double speed) {
 
-    // Based on cone values
+  public MoveToHigh(Arm arm, Intake intake, Double speed) {
     addCommands(new TiltArmToHeight(arm, intake, speed, 16.5),
-    new ExtendArmToLength(arm, speed, 30.0));
+    new ExtendArmToLength(arm, speed, 27.5));
   }
+  
 }

--- a/src/main/java/frc/robot/commands/arm/MoveTo/MoveToLow.java
+++ b/src/main/java/frc/robot/commands/arm/MoveTo/MoveToLow.java
@@ -1,24 +1,22 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
+// Copyright (c) 2022 FRC Team 2881 - The Lady Cans
+//
+// Open Source Software; you can modify and/or share it under the terms of BSD
+// license file in the root directory of this project.
 
 package frc.robot.commands.arm.MoveTo;
 
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+
 import frc.robot.commands.arm.ExtendArmToLength;
 import frc.robot.commands.arm.TiltArmToHeight;
 import frc.robot.subsystems.Arm;
 import frc.robot.subsystems.Intake;
 
-// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
-// information, see:
-// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
 public class MoveToLow extends SequentialCommandGroup {
-  /** Creates a new MoveToLow. */
+
   public MoveToLow(Arm arm, Intake intake, Double speed) {
-    // Add your commands in the addCommands() call, e.g.
-    // addCommands(new FooCommand(), new BarCommand());
     addCommands(new TiltArmToHeight(arm, intake, speed, 6.0),
     new ExtendArmToLength(arm, speed, 10.5));
   }
+  
 }

--- a/src/main/java/frc/robot/commands/arm/MoveTo/MoveToMedium.java
+++ b/src/main/java/frc/robot/commands/arm/MoveTo/MoveToMedium.java
@@ -1,24 +1,22 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
+// Copyright (c) 2022 FRC Team 2881 - The Lady Cans
+//
+// Open Source Software; you can modify and/or share it under the terms of BSD
+// license file in the root directory of this project.
 
 package frc.robot.commands.arm.MoveTo;
 
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+
 import frc.robot.commands.arm.ExtendArmToLength;
 import frc.robot.commands.arm.TiltArmToHeight;
 import frc.robot.subsystems.Arm;
 import frc.robot.subsystems.Intake;
 
-// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
-// information, see:
-// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
 public class MoveToMedium extends SequentialCommandGroup {
-  /** Creates a new MoveToMedium. */
-  public MoveToMedium(Arm arm, Intake intake, Double speed) {
-    // Based on Cone nodes
-    addCommands(new TiltArmToHeight(arm, intake, speed, 15.0),
-    new ExtendArmToLength(arm, speed, 13.0));
 
+  public MoveToMedium(Arm arm, Intake intake, Double speed) {
+    addCommands(new TiltArmToHeight(arm, intake, speed, 15.0),
+    new ExtendArmToLength(arm, speed, 12.0));
   }
+  
 }

--- a/src/main/java/frc/robot/commands/arm/MoveTo/MoveToPickup.java
+++ b/src/main/java/frc/robot/commands/arm/MoveTo/MoveToPickup.java
@@ -3,21 +3,18 @@
 // Open Source Software; you can modify and/or share it under the terms of BSD
 // license file in the root directory of this project.
 
-package frc.robot.commands.arm.Score;
+package frc.robot.commands.arm.MoveTo;
 
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 import frc.robot.commands.arm.TiltArmToHeight;
-import frc.robot.commands.arm.MoveTo.MoveToMedium;
 import frc.robot.subsystems.Arm;
 import frc.robot.subsystems.Intake;
-import frc.robot.subsystems.Suction;
 
-public class ScoreMedium extends SequentialCommandGroup {
-  
-  public ScoreMedium(Arm arm, Intake intake, Double speed, Suction suction) {
-    addCommands(new MoveToMedium(arm, intake, speed),
-    new TiltArmToHeight(arm, intake, speed, 11.5));
+public class MoveToPickup extends SequentialCommandGroup {
+
+  public MoveToPickup(Arm arm, Intake intake, Double speed) {
+    addCommands(new TiltArmToHeight(arm, intake, speed, 12.6));
   }
   
 }

--- a/src/main/java/frc/robot/commands/arm/Score/ScoreHigh.java
+++ b/src/main/java/frc/robot/commands/arm/Score/ScoreHigh.java
@@ -8,16 +8,16 @@ package frc.robot.commands.arm.Score;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 import frc.robot.commands.arm.TiltArmToHeight;
-import frc.robot.commands.arm.MoveTo.MoveToMedium;
+import frc.robot.commands.arm.MoveTo.MoveToHigh;
 import frc.robot.subsystems.Arm;
 import frc.robot.subsystems.Intake;
 import frc.robot.subsystems.Suction;
 
-public class ScoreMedium extends SequentialCommandGroup {
-  
-  public ScoreMedium(Arm arm, Intake intake, Double speed, Suction suction) {
-    addCommands(new MoveToMedium(arm, intake, speed),
-    new TiltArmToHeight(arm, intake, speed, 11.5));
+public class ScoreHigh extends SequentialCommandGroup {
+
+  public ScoreHigh(Arm arm, Intake intake, Double speed, Suction suction) {
+    addCommands(new MoveToHigh(arm, intake, speed),
+    new TiltArmToHeight(arm, intake, speed, 14.5));
   }
   
 }

--- a/src/main/java/frc/robot/commands/arm/TiltArm.java
+++ b/src/main/java/frc/robot/commands/arm/TiltArm.java
@@ -8,6 +8,7 @@ package frc.robot.commands.arm;
 import java.util.function.DoubleSupplier;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+
 import frc.robot.subsystems.Arm;
 
 /** Elevates the scoring arm. */
@@ -17,26 +18,24 @@ public class TiltArm extends CommandBase {
   
   public TiltArm(Arm arm, DoubleSupplier speed) {
     m_arm = arm;
+    addRequirements(m_arm);
+
     m_speed = speed;
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {}
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
     m_arm.runTilt(-m_speed.getAsDouble());
   }
 
-  // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
     m_arm.runTilt(0.0);
   }
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
     return false;

--- a/src/main/java/frc/robot/commands/arm/TiltArmToHeight.java
+++ b/src/main/java/frc/robot/commands/arm/TiltArmToHeight.java
@@ -18,43 +18,26 @@ public class TiltArmToHeight extends CommandBase {
   public TiltArmToHeight(Arm arm, Intake intake, Double speed, Double position) {
     m_arm = arm;
     m_intake = intake;
-    m_position = position;
+    addRequirements(m_arm, m_intake);
 
+    m_speed = speed;
+    m_position = position;
   }
 
   @Override
   public void initialize() {
-    System.out.println("Tilt Arm to height");
     m_arm.setDesiredTiltPosition(m_position);
   }
 
   @Override
-  public void execute() {
-    /* 
-    boolean intakeIsOut = m_intake.isOut;
-    boolean isSafe = m_arm.isSafeToTilt();
+  public void execute() {}
     
-    if(m_speed < 0){
-      if(intakeIsOut || isSafe == false){
-        m_arm.tilt(0.0);
-      } else {
-        m_arm.tilt(m_speed);
-      }
-    }*/
-  }
-    
-
   @Override
   public void end(boolean interrupted) {}
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-      if(Math.abs(m_arm.getTiltEncoderPosition() - m_position) < 0.1){
-        return true;
-      } else {
-        return false;
-      }
-    }
+    return Math.abs(m_arm.getTiltEncoderPosition() - m_position) < 0.1;
+  }
 
 }

--- a/src/main/java/frc/robot/commands/auto/FollowTrajectory.java
+++ b/src/main/java/frc/robot/commands/auto/FollowTrajectory.java
@@ -1,6 +1,7 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
+// Copyright (c) 2022 FRC Team 2881 - The Lady Cans
+//
+// Open Source Software; you can modify and/or share it under the terms of BSD
+// license file in the root directory of this project.
 
 package frc.robot.commands.auto;
 
@@ -8,41 +9,35 @@ import com.pathplanner.lib.PathPlannerTrajectory;
 import com.pathplanner.lib.commands.PPSwerveControllerCommand;
 
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 import frc.robot.Constants;
 import frc.robot.subsystems.Drive;
 
-/** Add your docs here. */
 public class FollowTrajectory extends SequentialCommandGroup {
-    public FollowTrajectory (PathPlannerTrajectory trajectory, boolean isFirstPath, Drive drive) {
+    public FollowTrajectory(PathPlannerTrajectory trajectory, boolean isFirstPath, Drive drive) {
         PIDController xPidController = new PIDController(0.01, 0, 0);
         PIDController yPidController = new PIDController(0.01, 0, 0);
         PIDController tPidController = new PIDController(5, 0, 0);
-        SmartDashboard.putData("X PID",xPidController);
-        SmartDashboard.putData("Y PID",yPidController);
-        SmartDashboard.putData("Theta PID",tPidController);
         addCommands(
             new InstantCommand(() -> {
                 // Reset odometry for the first path you run during auto
-                if(isFirstPath){
+                if (isFirstPath) {
                     drive.resetPose(trajectory.getInitialPose());
                 }
-              }),
+            }),
             new PPSwerveControllerCommand(
-                trajectory, 
-                drive::getPose, 
-                Constants.Drive.kDriveKinematics, 
-                //The PID controllers set to 0 work best since the swerve modules are already being tuned in the Drive PID Controllers.
+                trajectory,
+                drive::getPose,
+                Constants.Drive.kDriveKinematics,
+                // The PID controllers set to 0 work best since the swerve modules are already
+                // being tuned in the Drive PID Controllers.
                 xPidController,
                 yPidController,
                 tPidController,
-                drive::setModuleStates, 
-                true, 
-                drive
-                )
-        );
+                drive::setModuleStates,
+                true,
+                drive));
     }
 }

--- a/src/main/java/frc/robot/commands/clamps/AttachLeft.java
+++ b/src/main/java/frc/robot/commands/clamps/AttachLeft.java
@@ -8,24 +8,19 @@ package frc.robot.commands.clamps;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 
 public class AttachLeft extends CommandBase {
-  /** Creates a new AttachLeft. */
+
   public AttachLeft() {
-    // Use addRequirements() here to declare subsystem dependencies.
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {}
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {}
 
-  // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {}
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
     return false;

--- a/src/main/java/frc/robot/commands/clamps/AttachRight.java
+++ b/src/main/java/frc/robot/commands/clamps/AttachRight.java
@@ -8,24 +8,19 @@ package frc.robot.commands.clamps;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 
 public class AttachRight extends CommandBase {
-  /** Creates a new AttachRight. */
+
   public AttachRight() {
-    // Use addRequirements() here to declare subsystem dependencies.
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {}
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {}
 
-  // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {}
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
     return false;

--- a/src/main/java/frc/robot/commands/drive/DriveRobotCentric.java
+++ b/src/main/java/frc/robot/commands/drive/DriveRobotCentric.java
@@ -1,39 +1,36 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
+// Copyright (c) 2022 FRC Team 2881 - The Lady Cans
+//
+// Open Source Software; you can modify and/or share it under the terms of BSD
+// license file in the root directory of this project.
 
 package frc.robot.commands.drive;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+
 import frc.robot.lib.Enums.SwerveDriveMode;
 import frc.robot.subsystems.Drive;
 
 public class DriveRobotCentric extends CommandBase {
   private final Drive m_drive;
 
-  /** Creates a new ZeroHeading. */
   public DriveRobotCentric(Drive drive) {
     m_drive = drive;
     addRequirements(drive);
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {
     m_drive.setDriveMode(SwerveDriveMode.ROBOT_CENTRIC);
   }
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {}
 
-  // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
     m_drive.setDriveMode(SwerveDriveMode.FIELD_CENTRIC);
   }
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
     return false;

--- a/src/main/java/frc/robot/commands/drive/DriveWithJoysticks.java
+++ b/src/main/java/frc/robot/commands/drive/DriveWithJoysticks.java
@@ -8,6 +8,7 @@ package frc.robot.commands.drive;
 import java.util.function.DoubleSupplier;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+
 import frc.robot.Constants;
 import frc.robot.subsystems.Drive;
 
@@ -17,28 +18,32 @@ public class DriveWithJoysticks extends CommandBase {
   private final DoubleSupplier m_translationYSupplier;
   private final DoubleSupplier m_rotationSupplier;
 
-  public DriveWithJoysticks(Drive drive,
-  DoubleSupplier translationXSupplier,
-  DoubleSupplier translationYSupplier,
-  DoubleSupplier rotationSupplier) {
+  public DriveWithJoysticks(
+    Drive drive,
+    DoubleSupplier translationXSupplier,
+    DoubleSupplier translationYSupplier,
+    DoubleSupplier rotationSupplier
+  ) {
     m_drive = drive;
+    addRequirements(m_drive);
+
     m_translationXSupplier = translationXSupplier;
     m_translationYSupplier = translationYSupplier;
     m_rotationSupplier = rotationSupplier;
-    
-    addRequirements(m_drive);
   }
 
   @Override
   public void execute() {
-   m_drive.drive(m_translationXSupplier.getAsDouble() * Constants.Drive.kMaxSpeedMetersPerSecond,
-               m_translationYSupplier.getAsDouble() * Constants.Drive.kMaxSpeedMetersPerSecond, 
-               m_rotationSupplier.getAsDouble() * Constants.Drive.kMaxAngularSpeed);
+    m_drive.drive(
+      m_translationXSupplier.getAsDouble() * Constants.Drive.kMaxSpeedMetersPerSecond,
+      m_translationYSupplier.getAsDouble() * Constants.Drive.kMaxSpeedMetersPerSecond, 
+      m_rotationSupplier.getAsDouble() * Constants.Drive.kMaxAngularSpeed
+    );
   }
 
   @Override
   public void end(boolean interrupted) {
-   m_drive.drive(0, 0, 0);
+    m_drive.drive(0, 0, 0);
   }
 
   @Override

--- a/src/main/java/frc/robot/commands/drive/ResetSwerve.java
+++ b/src/main/java/frc/robot/commands/drive/ResetSwerve.java
@@ -6,34 +6,30 @@
 package frc.robot.commands.drive;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+
 import frc.robot.subsystems.Drive;
 
 public class ResetSwerve extends CommandBase {
   private final Drive m_drive;
 
-  /** Creates a new ResetSwerve. */
   public ResetSwerve(Drive drive) {
     m_drive = drive;
     addRequirements(drive);
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {
     m_drive.resetSwerve();
   }
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {}
 
-  // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {}
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return false;
+    return true;
   }
 }

--- a/src/main/java/frc/robot/commands/drive/ZeroHeading.java
+++ b/src/main/java/frc/robot/commands/drive/ZeroHeading.java
@@ -1,6 +1,7 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
+// Copyright (c) 2022 FRC Team 2881 - The Lady Cans
+//
+// Open Source Software; you can modify and/or share it under the terms of BSD
+// license file in the root directory of this project.
 
 package frc.robot.commands.drive;
 
@@ -11,27 +12,22 @@ import frc.robot.subsystems.Drive;
 public class ZeroHeading extends CommandBase {
   private final Drive m_drive;
 
-  /** Creates a new ZeroHeading. */
   public ZeroHeading(Drive drive) {
     m_drive = drive;
     addRequirements(drive);
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {
     m_drive.zeroHeading();
   }
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {}
 
-  // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {}
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
     return true;

--- a/src/main/java/frc/robot/commands/intake/ExtendIntakeArm.java
+++ b/src/main/java/frc/robot/commands/intake/ExtendIntakeArm.java
@@ -6,10 +6,9 @@
 package frc.robot.commands.intake;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.lib.DataLog;
+
 import frc.robot.subsystems.Intake;
 
-/** Extends the intake out. */
 public class ExtendIntakeArm extends CommandBase {
   private Intake m_intake;
 
@@ -18,23 +17,17 @@ public class ExtendIntakeArm extends CommandBase {
     addRequirements(intake);
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {
     m_intake.extend(); 
   }
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
-  public void execute() {
-  }
+  public void execute() {}
 
-  // Called once the command ends or is interrupted.
   @Override
-  public void end(boolean interrupted) {
-  }
+  public void end(boolean interrupted) {}
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
     return true;

--- a/src/main/java/frc/robot/commands/intake/RetractIntakeArm.java
+++ b/src/main/java/frc/robot/commands/intake/RetractIntakeArm.java
@@ -6,10 +6,9 @@
 package frc.robot.commands.intake;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.lib.DataLog;
+
 import frc.robot.subsystems.Intake;
 
-/** Retracts the intake in. */
 public class RetractIntakeArm extends CommandBase {
   private Intake m_intake;
   
@@ -18,23 +17,17 @@ public class RetractIntakeArm extends CommandBase {
     addRequirements(intake);
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {
     m_intake.retract(); 
   }
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
-  public void execute() {
-  }
+  public void execute() {}
 
-  // Called once the command ends or is interrupted.
   @Override
-  public void end(boolean interrupted) {
-  }
+  public void end(boolean interrupted) {}
   
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
     return true;

--- a/src/main/java/frc/robot/commands/intake/RunRollersInward.java
+++ b/src/main/java/frc/robot/commands/intake/RunRollersInward.java
@@ -6,35 +6,30 @@
 package frc.robot.commands.intake;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+
 import frc.robot.subsystems.Intake;
 
-/** Runs the rollers forward.*/
 public class RunRollersInward extends CommandBase {
   private Intake m_intake;
   
   public RunRollersInward(Intake intake) {
     m_intake = intake;
-    
+    addRequirements(m_intake);
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {
     m_intake.runRollersInward();
   }
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
-  public void execute() {
-  }
+  public void execute() {}
 
-  // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
     m_intake.stopRollers();
   }
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
     return false;

--- a/src/main/java/frc/robot/commands/intake/RunRollersOutward.java
+++ b/src/main/java/frc/robot/commands/intake/RunRollersOutward.java
@@ -6,6 +6,7 @@
 package frc.robot.commands.intake;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+
 import frc.robot.subsystems.Intake;
 
 /** Runs the rollers backward. */
@@ -14,27 +15,22 @@ public class RunRollersOutward extends CommandBase {
   
   public RunRollersOutward(Intake intake) {
     m_intake = intake;
-    
+    addRequirements(m_intake);
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {
     m_intake.runRollersOutward();
   }
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
-  public void execute() {
-  }
+  public void execute() {}
 
-  // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
     m_intake.stopRollers();
   }
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
     return false;

--- a/src/main/java/frc/robot/commands/suction/DisableSuction.java
+++ b/src/main/java/frc/robot/commands/suction/DisableSuction.java
@@ -6,31 +6,28 @@
 package frc.robot.commands.suction;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+
 import frc.robot.subsystems.Suction;
 
 public class DisableSuction extends CommandBase {
   private Suction m_suction;
 
   public DisableSuction(Suction suction) {
-    addRequirements(suction);
     m_suction = suction;
+    addRequirements(m_suction);
   }
 
-  // Called when the command is initially scheduled.
   @Override
   public void initialize() {
     m_suction.disable();
   }
 
-  // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {}
 
-  // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {}
 
-  // Returns true when the command should end.
   @Override
   public boolean isFinished() {
     return true;

--- a/src/main/java/frc/robot/commands/suction/ToggleSuction.java
+++ b/src/main/java/frc/robot/commands/suction/ToggleSuction.java
@@ -9,17 +9,17 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 
 import frc.robot.subsystems.Suction;
 
-public class EnableSuction extends CommandBase {
+public class ToggleSuction extends CommandBase {
   private Suction m_suction;
 
-  public EnableSuction(Suction suction) {
+  public ToggleSuction(Suction suction) {
     m_suction = suction;
     addRequirements(m_suction);
   }
 
   @Override
   public void initialize() {
-    m_suction.enable();
+    m_suction.toggle();
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -90,7 +90,7 @@ public class Arm extends SubsystemBase {
 
   
   /*
-   * Sets the Extension position to given value. 15 inches of movement.
+   * Sets the Extension position to given value.
    */
   public void setDesiredExtensionPosition(double position) {
     // TODO: Add ability to set the speed
@@ -101,16 +101,17 @@ public class Arm extends SubsystemBase {
    * Sets the Tilt position to given value
    */
   public void setDesiredTiltPosition(double position) {
+    // TODO: Add ability to set the speed
     m_tiltPID.setReference(position, CANSparkMax.ControlType.kPosition);
   }
 
   // In inches
-  public Double getExtensionEncoderPosition(){
+  public Double getExtensionEncoderPosition() {
     return m_extensionMotorEncoder.getPosition();
   }
 
   // In inches
-  public Double getTiltEncoderPosition(){
+  public Double getTiltEncoderPosition() {
     return m_tiltMotorEncoder.getPosition();
   }
 
@@ -123,7 +124,7 @@ public class Arm extends SubsystemBase {
   }
 
   public void enableTiltSoftLimits(boolean enable){
-    if(enable == true){
+    if (enable) {
       m_tiltMotor.enableSoftLimit(CANSparkMax.SoftLimitDirection.kForward, true);
       m_tiltMotor.enableSoftLimit(CANSparkMax.SoftLimitDirection.kReverse, true);
     } else {
@@ -133,7 +134,7 @@ public class Arm extends SubsystemBase {
   }
 
   public void enableExtendSoftLimits(boolean enable){
-    if(enable == true){
+    if (enable) {
       m_extensionMotor.enableSoftLimit(CANSparkMax.SoftLimitDirection.kForward, true);
       m_extensionMotor.enableSoftLimit(CANSparkMax.SoftLimitDirection.kReverse, true);
     } else {
@@ -142,30 +143,19 @@ public class Arm extends SubsystemBase {
     }
   }
 
-  public boolean isSafeToExtend(){
+  public boolean isSafeToExtend() {
     double tilt = m_tiltMotorEncoder.getPosition();
-
-    if(tilt < Constants.Arm.kMinSafeTilt){
-      m_isExtendSafe = false; 
-    } else {
-      m_isExtendSafe = true;
-    }
-
+    m_isExtendSafe = tilt < Constants.Arm.kMinSafeTilt;
     return m_isExtendSafe;
   }
 
-  public boolean isSafeToTilt(){
+  public boolean isSafeToTilt() {
     double extensionPosition = m_extensionMotorEncoder.getPosition();
     double tiltPosition = m_tiltMotorEncoder.getPosition();
-
-    if(tiltPosition > Constants.Arm.kMinSafeTilt){
+    if (tiltPosition > Constants.Arm.kMinSafeTilt) {
       m_isTiltSafe = true;
-    } else{
-      if(extensionPosition > 0){
-        m_isTiltSafe = false;
-      } else{
-        m_isTiltSafe = true;
-      }
+    } else {
+      m_isTiltSafe = extensionPosition > 0;
     }
     return m_isTiltSafe;
   }

--- a/src/main/java/frc/robot/subsystems/Clamps.java
+++ b/src/main/java/frc/robot/subsystems/Clamps.java
@@ -8,11 +8,10 @@ package frc.robot.subsystems;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class Clamps extends SubsystemBase {
-  /** Creates a new Clamps. */
+
   public Clamps() {}
 
   @Override
   public void periodic() {
-    // This method will be called once per scheduler run
   }
 }

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -196,8 +196,7 @@ public class Drive extends SubsystemBase {
    * @param desiredStates The desired SwerveModule states.
    */
   public void setModuleStates(SwerveModuleState[] desiredStates) {
-    SwerveDriveKinematics.desaturateWheelSpeeds(
-        desiredStates, Constants.Drive.kMaxSpeedMetersPerSecond);
+    SwerveDriveKinematics.desaturateWheelSpeeds(desiredStates, Constants.Drive.kMaxSpeedMetersPerSecond);
     m_frontLeft.setDesiredState(desiredStates[0]);
     m_frontRight.setDesiredState(desiredStates[1]);
     m_rearLeft.setDesiredState(desiredStates[2]);

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -12,13 +12,13 @@ import com.revrobotics.ColorMatchResult;
 import com.revrobotics.ColorSensorV3;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.CANSparkMax.IdleMode;
-import com.revrobotics.CANSparkMax.SoftLimitDirection;
 
 import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.wpilibj.I2C.Port;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
 import frc.robot.Constants;
 
 public class Intake extends SubsystemBase {
@@ -37,7 +37,6 @@ public class Intake extends SubsystemBase {
     m_rollers.setInverted(false);
     m_rollers.setIdleMode(IdleMode.kBrake);
     m_rollers.setSmartCurrentLimit(Constants.Intake.kCurrentLimit);
-
 
     m_intakeArmMotor = new CANSparkMax(Constants.Intake.kIntakeArmCANId, MotorType.kBrushless);
     m_intakeArmMotor.restoreFactoryDefaults();
@@ -132,16 +131,12 @@ public class Intake extends SubsystemBase {
     }
 
     // Use for finding the Color values for cone/cube.
-    Color color = m_colorSensor.getColor();
+    // Color color = m_colorSensor.getColor();
+    // SmartDashboard.putNumber("Intake/GamePiece/Red", color.red);
+    // SmartDashboard.putNumber("Green", color.green);
+    // SmartDashboard.putNumber("Blue", color.blue);
 
-    SmartDashboard.putNumber("Red", color.red);
-    SmartDashboard.putNumber("Green", color.green);
-    SmartDashboard.putNumber("Blue", color.blue);
-
-    SmartDashboard.putNumber("Intake/EncoderVelocity", m_intakeArmMotorEncoder.getVelocity());
-    SmartDashboard.putNumber("Intake/MotorSpeed", m_intakeArmMotor.get()); 
-
-
+    updateTelemetry();
   }
 
   @Override
@@ -156,5 +151,10 @@ public class Intake extends SubsystemBase {
 
   public boolean isOut(){
     return isOut;
+  }
+
+  private void updateTelemetry() {
+    SmartDashboard.putNumber("Intake/EncoderVelocity", m_intakeArmMotorEncoder.getVelocity());
+    SmartDashboard.putNumber("Intake/MotorSpeed", m_intakeArmMotor.get()); 
   }
 }

--- a/src/main/java/frc/robot/subsystems/PrettyLights.java
+++ b/src/main/java/frc/robot/subsystems/PrettyLights.java
@@ -8,11 +8,11 @@ package frc.robot.subsystems;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class PrettyLights extends SubsystemBase {
-  /** Creates a new PrettyLights. */
+
   public PrettyLights() {}
 
   @Override
   public void periodic() {
-    // This method will be called once per scheduler run
   }
+
 }

--- a/src/main/java/frc/robot/subsystems/Suction.java
+++ b/src/main/java/frc/robot/subsystems/Suction.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj.AnalogInput;
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
 import edu.wpi.first.wpilibj.Solenoid;
 import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj.RobotController;
@@ -119,6 +120,14 @@ public class Suction extends SubsystemBase {
   public void disable() {
     m_isEnabled = false;
     m_isDisabling = true;
+  }
+
+  public void toggle() {
+    if (m_isEnabled) {
+      disable();
+    } else {
+      enable();
+    }
   }
 
   private void updateTelemetry() {


### PR DESCRIPTION
Students: Zosia, Erika
Mentor: Robert

- Made drive mode trigger for robot centric activate at 0.9 on right trigger almost all the way in
- Fix inversion for manual arm extension with joystick
- Fix swerve module reset to run only once on button press - not while held
- Disable intake subsystem in code for now to reduce log complaints
- Create single suction toggle button for manipulator in place of separate buttons
- Add score high command for arm
- Add move arm to substation pickup height command
- Tweak arm extension retract limit as workaround for leadscrew jamming and motor fire
- Code formatting to reduce clutter for faster editing during practice runs